### PR TITLE
Remove legacy URL redirect from sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -148,12 +148,5 @@
     <priority>0.3</priority>
   </url>
 
-  <!-- Legacy URL redirect -->
-  <url>
-    <loc>https://notecounter.vercel.app/</loc>
-    <lastmod>2025-04-08</lastmod>
-    <changefreq>never</changefreq>
-    <priority>0.1</priority>
-  </url>
 
 </urlset>


### PR DESCRIPTION
This pull request removes a legacy URL redirect from the `public/sitemap.xml` file. The change eliminates the `<url>` entry for `https://notecounter.vercel.app/`, which was marked with low priority and a `changefreq` of `never`.